### PR TITLE
Add wallet unlock payment flow with enhanced messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -4200,7 +4200,6 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
         .chip-progress > div { height:100%; width:100%; background: linear-gradient(90deg, #ff2e63 0%, #ff874d 50%, #ffd400 100%); background-size:200% 100%; transition: width 0.6s ease, background-position 0.6s ease; }
         #levelChipName, #levelChipPercent { color: #fff !important; font-weight:700; }
         #levelChipPercent { opacity: 0.95; font-size:0.9rem; }
-        #walletChipAmount { font-weight:800; font-size:1.05rem; color:#fff !important; }
         #jcoinRate { color:#fff !important; font-weight:700; }
         .wallet-chip .chip-sub { color: rgba(255,255,255,0.9) !important; font-size:0.85rem; }
         /* Ensure hover states remain visible */

--- a/index.html
+++ b/index.html
@@ -4200,6 +4200,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
         .chip-progress > div { height:100%; width:100%; background: linear-gradient(90deg, #ff2e63 0%, #ff874d 50%, #ffd400 100%); background-size:200% 100%; transition: width 0.6s ease, background-position 0.6s ease; }
         #levelChipName, #levelChipPercent { color: #fff !important; font-weight:700; }
         #levelChipPercent { opacity: 0.95; font-size:0.9rem; }
+        #walletChipAmount { font-weight:800; font-size:1.05rem; color:#fff !important; }
         #jcoinRate { color:#fff !important; font-weight:700; }
         .wallet-chip .chip-sub { color: rgba(255,255,255,0.9) !important; font-size:0.85rem; }
         /* Ensure hover states remain visible */
@@ -4528,7 +4529,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                                 <li><strong>Deterministic inspiration</strong> — time-seeded algorithms deliver consistent, non-repetitive daily prompts.</li>
                                 <li><strong>Scripture indexing</strong> ��� fast chapter and verse lookup with offline resume and reading progress persistence.</li>
                                 <li><strong>Privacy-first profiles</strong> — local-first defaults with optional cloud sync for registered users.</li>
-                                <li><strong>Content safety</strong> ��� layered moderation combining heuristics and community signals.</li>
+                                <li><strong>Content safety</strong> ���� layered moderation combining heuristics and community signals.</li>
                             </ul>
                         </div>
 
@@ -4602,6 +4603,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                 <a href="#" id="walletChipLink" class="chip wallet-chip">
                     <i class="fas fa-wallet"></i>
                     <div class="chip-text">
+                        <div><span id="walletChipAmount">0</span> JCoins</div>
                         <div class="chip-sub">Rate: ₦<span id="jcoinRate">0</span>/J</div>
                     </div>
                 </a>
@@ -10936,7 +10938,8 @@ async function fetchAndDisplayPosts() {
                             hideGlobalAnnouncement();
                         }
                                         // Update wallet chip
-                if (homeChipsRow && jcoinRateSpan) {
+                if (homeChipsRow && walletChipAmount && jcoinRateSpan) {
+                    walletChipAmount.textContent = String(currentUserProfileData?.jCoins || 0);
                     jcoinRateSpan.textContent = String(currentSystemSettings?.jcoinNairaRate || 0);
                 // Also update wallet.html oneJcoinRateDisplay if opened in same session/window (best-effort)
                 try { if (window.parent && window.parent.document) { const oneEl = window.parent.document.getElementById('oneJcoinRateDisplay'); if (oneEl && currentSystemSettings?.jcoinNairaRate) oneEl.textContent = `₦${(1/currentSystemSettings.jcoinNairaRate).toFixed(2)} NGN`; } } catch(e) {}
@@ -13373,58 +13376,6 @@ async function fetchAndDisplayPosts() {
   window.addEventListener('beforeunload', ()=>{ if(window.__nuvia3dInterval) clearInterval(window.__nuvia3dInterval); });
 })();
 </script>
-    <main>
-        <section class="card" style="margin:24px auto; max-width:500px;">
-            <h2>Your JCoin Balance</h2>
-            <p>JCoins: <span id="jcoin-balance">...</span></p>
-            <p>Naira Equivalent: ₦<span id="naira-equivalent">...</span></p>
-        </section>
-    </main>
-    <script src="assets/js/lazy-images.js" defer></script>
-    <script>
-    // --- JCoin currency rate logic (copied from wallet.html) ---
-    let currentSystemSettings = { jcoinNairaRate: 0.005 };
-    const jcoinBalanceSpan = document.getElementById('jcoin-balance');
-    const nairaEquivalentSpan = document.getElementById('naira-equivalent');
-
-    async function fetchSystemSettings() {
-        if (typeof getDoc === 'function' && typeof SYSTEM_SETTINGS_DOC_REF !== 'undefined') {
-            const docSnap = await getDoc(SYSTEM_SETTINGS_DOC_REF);
-            if (docSnap.exists()) {
-                currentSystemSettings = docSnap.data();
-            }
-        }
-    }
-
-    async function fetchJCoinBalance() {
-        let jCoins = 0;
-        if (typeof getDoc === 'function' && typeof doc === 'function' && typeof db !== 'undefined' && typeof appId !== 'undefined' && typeof auth !== 'undefined') {
-            if (typeof onAuthStateChanged === 'function') {
-                onAuthStateChanged(auth, async (user) => {
-                    if (user) {
-                        await fetchSystemSettings();
-                        const userProfileDocRef = doc(db, "artifacts", appId, "users", user.uid, "profiles", "user_profile");
-                        const docSnap = await getDoc(userProfileDocRef);
-                        if (docSnap.exists()) {
-                            jCoins = docSnap.data().jCoins || 0;
-                        }
-                        jcoinBalanceSpan.textContent = jCoins;
-                        nairaEquivalentSpan.textContent = (jCoins * currentSystemSettings.jcoinNairaRate).toFixed(3);
-                    } else {
-                        jcoinBalanceSpan.textContent = 0;
-                        nairaEquivalentSpan.textContent = (0).toFixed(3);
-                    }
-                });
-            }
-        } else {
-            // Fallback for demo
-            jcoinBalanceSpan.textContent = jCoins;
-            nairaEquivalentSpan.textContent = (jCoins * currentSystemSettings.jcoinNairaRate).toFixed(3);
-        }
-    }
-
-    fetchJCoinBalance();
-    </script>
 <div id="mediaViewer" class="media-viewer-overlay" role="dialog" aria-modal="true" aria-label="Image preview" style="display:none;">
   <div class="media-viewer-content">
     <button id="mediaViewerClose" class="media-viewer-close" aria-label="Close">&times;</button>

--- a/index.html
+++ b/index.html
@@ -12408,6 +12408,20 @@ async function fetchAndDisplayPosts() {
             // Initialize DOM elements first
             initializeDOMElements();
 
+            // Open wallet unlock panel when clicking JCoin rate
+            try {
+                if (window.jcoinRateSpan) {
+                    const openWalletLockedPanel = (ev) => {
+                        ev.preventDefault();
+                        ev.stopPropagation();
+                        const m = document.getElementById('walletLockedModal');
+                        if (m) { m.style.display = 'block'; setTimeout(() => m.classList.add('active'), 0); }
+                    };
+                    window.jcoinRateSpan.addEventListener('click', openWalletLockedPanel);
+                    if (window.jcoinRateSpan.parentElement) window.jcoinRateSpan.parentElement.addEventListener('click', openWalletLockedPanel);
+                }
+            } catch (_) {}
+
             // Wire post composer listeners after DOM is ready
             if (postMediaUpload) {
                 postMediaUpload.addEventListener('change', (event) => {

--- a/index.html
+++ b/index.html
@@ -4814,7 +4814,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                     </ul>
                     <div class="button-group" style="display:flex;gap:10px;justify-content:flex-end;">
                         <button id="closeWalletLockedBtn" class="modal-button cancel-button">Close</button>
-                        <a id="walletPayBtn" href="/Wallet.html?unlock=1&amount=5000" class="modal-button confirm-button">Pay ₦5000</a>
+                        <a id="walletPayBtn" href="/Wallet.html?unlock=1&amount=5000" class="modal-button confirm-button">Pay ���5000</a>
                     </div>
                 </div>
             </div>
@@ -10938,8 +10938,7 @@ async function fetchAndDisplayPosts() {
                             hideGlobalAnnouncement();
                         }
                                         // Update wallet chip
-                if (homeChipsRow && walletChipAmount && jcoinRateSpan) {
-                    walletChipAmount.textContent = String(currentUserProfileData?.jCoins || 0);
+                if (homeChipsRow && jcoinRateSpan) {
                     jcoinRateSpan.textContent = String(currentSystemSettings?.jcoinNairaRate || 0);
                 // Also update wallet.html oneJcoinRateDisplay if opened in same session/window (best-effort)
                 try { if (window.parent && window.parent.document) { const oneEl = window.parent.document.getElementById('oneJcoinRateDisplay'); if (oneEl && currentSystemSettings?.jcoinNairaRate) oneEl.textContent = `₦${(1/currentSystemSettings.jcoinNairaRate).toFixed(2)} NGN`; } } catch(e) {}

--- a/index.html
+++ b/index.html
@@ -4806,10 +4806,69 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
             <div id="walletLockedModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="walletLockedTitle" style="display:none;">
                 <div class="modal-content">
                     <h3 id="walletLockedTitle"><i class="fas fa-lock"></i> Wallet Locked</h3>
-                    <p style="color:var(--text-light);">Your wallet is locked. Pay ₦5000 to request unlock. A developer will unlock it after confirming your payment.</p>
+                    <p class="wallet-locked-message">Unlock your wallet now and get back to full power. A one‑time ₦5,000 verification keeps payments secure and lets a developer unlock your wallet fast after review.</p>
+                    <ul class="wallet-locked-message" style="margin:8px 0 0 18px;">
+                        <li>Priority review by a developer</li>
+                        <li>Faster access to JCoins and features</li>
+                        <li>Secure, one‑time verification fee</li>
+                    </ul>
                     <div class="button-group" style="display:flex;gap:10px;justify-content:flex-end;">
                         <button id="closeWalletLockedBtn" class="modal-button cancel-button">Close</button>
                         <a id="walletPayBtn" href="/Wallet.html?unlock=1&amount=5000" class="modal-button confirm-button">Pay ₦5000</a>
+                    </div>
+                </div>
+            </div>
+
+            <style>
+                .wallet-locked-message { color: var(--text-light); }
+                #walletPayBtn { background: linear-gradient(135deg, #ff2aa3, #ffd43b); border-color: transparent; color: #fff; }
+                #walletPayBtn:hover { transform: translateY(-1px); filter: brightness(1.05); }
+                #walletPaymentDetailsModal .modal-content { max-width: 520px; }
+                #walletPaymentDetailsModal .input-group { display:flex; flex-direction:column; gap:6px; margin:10px 0; }
+                #walletPaymentDetailsModal input[type="text"],
+                #walletPaymentDetailsModal input[type="number"],
+                #walletPaymentDetailsModal input[type="datetime-local"],
+                #walletPaymentDetailsModal textarea {
+                    padding: 8px 10px; border-radius: 8px; border: 1px solid var(--border-light);
+                    background: var(--input-background); color: var(--white);
+                }
+                #walletPaymentDetailsModal textarea { min-height: 80px; resize: vertical; }
+            </style>
+
+            <!-- Wallet Payment Details Modal -->
+            <div id="walletPaymentDetailsModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="walletPaymentDetailsTitle" style="display:none;">
+                <div class="modal-content">
+                    <h3 id="walletPaymentDetailsTitle"><i class="fas fa-receipt"></i> Submit Payment Details</h3>
+                    <p class="wallet-locked-message">Upload your bank transfer proof and fill in the details below. A developer will verify and unlock your wallet shortly.</p>
+
+                    <div class="input-group">
+                        <label for="walletPayAmountInput">Amount (NGN)</label>
+                        <input type="number" id="walletPayAmountInput" value="5000" readonly>
+                    </div>
+                    <div class="input-group">
+                        <label for="walletBankNameInput">Bank Name</label>
+                        <input type="text" id="walletBankNameInput" placeholder="e.g., GTBank, Access Bank">
+                    </div>
+                    <div class="input-group">
+                        <label for="walletTxRefInput">Transaction Reference</label>
+                        <input type="text" id="walletTxRefInput" placeholder="e.g., REF123456 or narration">
+                    </div>
+                    <div class="input-group">
+                        <label for="walletPaidAtInput">Payment Date & Time</label>
+                        <input type="datetime-local" id="walletPaidAtInput">
+                    </div>
+                    <div class="input-group">
+                        <label for="walletNoteInput">Additional Notes (optional)</label>
+                        <textarea id="walletNoteInput" placeholder="Anything else we should know"></textarea>
+                    </div>
+                    <div class="input-group">
+                        <label for="walletReceiptInput">Upload Receipt/Screenshot</label>
+                        <input type="file" id="walletReceiptInput" accept="image/*">
+                    </div>
+
+                    <div class="button-group" style="display:flex;gap:10px;justify-content:flex-end;">
+                        <button id="cancelWalletPaymentBtn" class="modal-button cancel-button">Cancel</button>
+                        <button id="submitWalletPaymentBtn" class="modal-button confirm-button"><i class="fas fa-paper-plane"></i> Submit</button>
                     </div>
                 </div>
             </div>
@@ -4873,7 +4932,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                         
                         <div class="premium-tier-option" data-tier="elite">
                             <div class="tier-header">
-                                <span class="tier-badge">👑 Elite</span>
+                                <span class="tier-badge">�� Elite</span>
                                 <span class="tier-price">$39.99/month</span>
                             </div>
                             <ul class="tier-features">
@@ -12419,6 +12478,67 @@ async function fetchAndDisplayPosts() {
                     };
                     window.jcoinRateSpan.addEventListener('click', openWalletLockedPanel);
                     if (window.jcoinRateSpan.parentElement) window.jcoinRateSpan.parentElement.addEventListener('click', openWalletLockedPanel);
+                }
+            } catch (_) {}
+
+            // Open payment details panel when clicking "Pay ₦5000"
+            try {
+                const walletPayBtn = document.getElementById('walletPayBtn');
+                const payModal = document.getElementById('walletPaymentDetailsModal');
+                const closeLockedBtn = document.getElementById('closeWalletLockedBtn');
+                const cancelPayBtn = document.getElementById('cancelWalletPaymentBtn');
+                const submitPayBtn = document.getElementById('submitWalletPaymentBtn');
+
+                const openPayPanel = (ev) => {
+                    ev.preventDefault(); ev.stopPropagation();
+                    const locked = document.getElementById('walletLockedModal');
+                    if (locked) { locked.classList.remove('active'); setTimeout(()=>{ locked.style.display='none'; }, 150); }
+                    if (payModal) { payModal.style.display='block'; setTimeout(()=>payModal.classList.add('active'),0); }
+                };
+                const closePayPanel = () => { if (payModal) { payModal.classList.remove('active'); setTimeout(()=>{ payModal.style.display='none'; }, 200); } };
+
+                if (walletPayBtn && !walletPayBtn.dataset.bound) { walletPayBtn.addEventListener('click', openPayPanel); walletPayBtn.dataset.bound = '1'; }
+                if (cancelPayBtn && !cancelPayBtn.dataset.bound) { cancelPayBtn.addEventListener('click', (e)=>{ e.preventDefault(); closePayPanel(); }); cancelPayBtn.dataset.bound='1'; }
+                if (payModal && !payModal.dataset.boundOutside) { payModal.addEventListener('click', (e)=>{ if (e.target === payModal) closePayPanel(); }); payModal.dataset.boundOutside='1'; }
+
+                if (submitPayBtn && !submitPayBtn.dataset.bound) {
+                    submitPayBtn.addEventListener('click', async (e) => {
+                        e.preventDefault();
+                        try {
+                            if (!currentUser || !appId) { showMessageBox('Please sign in to continue.', 'error'); return; }
+                            const amount = 5000;
+                            const bankName = (document.getElementById('walletBankNameInput')?.value || '').trim();
+                            const txRef = (document.getElementById('walletTxRefInput')?.value || '').trim();
+                            const paidAt = (document.getElementById('walletPaidAtInput')?.value || '').trim();
+                            const note = (document.getElementById('walletNoteInput')?.value || '').trim();
+                            const fileInput = document.getElementById('walletReceiptInput');
+                            let receiptUrl = null;
+                            if (fileInput && fileInput.files && fileInput.files[0]) {
+                                showMessageBox('Uploading receipt...', 'loading', true);
+                                const uploaded = await uploadMediaToCloudinary(fileInput.files[0]);
+                                if (!uploaded) { showMessageBox('Receipt upload failed. You can submit without image.', 'warning'); }
+                                else { receiptUrl = uploaded; }
+                            }
+                            const payload = {
+                                userId: currentUser.uid,
+                                amountNaira: amount,
+                                bankName: bankName || null,
+                                transactionRef: txRef || null,
+                                paidAt: paidAt || null,
+                                note: note || null,
+                                receiptUrl: receiptUrl || null,
+                                status: 'pending',
+                                createdAt: serverTimestamp()
+                            };
+                            await addDoc(collection(db, 'artifacts', appId, 'wallet_unlock_requests'), payload);
+                            closePayPanel();
+                            showMessageBox('Payment details sent. A developer will verify and unlock your wallet shortly.', 'success');
+                        } catch (err) {
+                            console.error('Nuvia_ERROR: submit wallet payment', err);
+                            showMessageBox('Failed to send details. Please try again.', 'error');
+                        }
+                    });
+                    submitPayBtn.dataset.bound='1';
                 }
             } catch (_) {}
 

--- a/index.html
+++ b/index.html
@@ -4603,7 +4603,6 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                 <a href="#" id="walletChipLink" class="chip wallet-chip">
                     <i class="fas fa-wallet"></i>
                     <div class="chip-text">
-                        <div><span id="walletChipAmount">0</span> JCoins</div>
                         <div class="chip-sub">Rate: ₦<span id="jcoinRate">0</span>/J</div>
                     </div>
                 </a>
@@ -4814,7 +4813,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                     </ul>
                     <div class="button-group" style="display:flex;gap:10px;justify-content:flex-end;">
                         <button id="closeWalletLockedBtn" class="modal-button cancel-button">Close</button>
-                        <a id="walletPayBtn" href="/Wallet.html?unlock=1&amount=5000" class="modal-button confirm-button">Pay ���5000</a>
+                        <a id="walletPayBtn" href="/Wallet.html?unlock=1&amount=5000" class="modal-button confirm-button">Pay ₦5000</a>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -4529,7 +4529,7 @@ header .user-profile-header{display:flex;align-items:center;gap:10px;flex:1 1 au
                                 <li><strong>Deterministic inspiration</strong> — time-seeded algorithms deliver consistent, non-repetitive daily prompts.</li>
                                 <li><strong>Scripture indexing</strong> ��� fast chapter and verse lookup with offline resume and reading progress persistence.</li>
                                 <li><strong>Privacy-first profiles</strong> — local-first defaults with optional cloud sync for registered users.</li>
-                                <li><strong>Content safety</strong> ���� layered moderation combining heuristics and community signals.</li>
+                                <li><strong>Content safety</strong> ��� layered moderation combining heuristics and community signals.</li>
                             </ul>
                         </div>
 
@@ -10939,8 +10939,10 @@ async function fetchAndDisplayPosts() {
                         }
                                         // Update wallet chip
                 if (homeChipsRow && walletChipAmount && jcoinRateSpan) {
-                    walletChipAmount.textContent = String(currentUserProfileData?.jCoins || 0);
-                    jcoinRateSpan.textContent = String(currentSystemSettings?.jcoinNairaRate || 0);
+                    const jCoinsBal = Number(currentUserProfileData?.jCoins || 0);
+                    walletChipAmount.textContent = String(jCoinsBal);
+                    const computedRate = (jCoinsBal * 0.005).toFixed(3);
+                    jcoinRateSpan.textContent = computedRate;
                 // Also update wallet.html oneJcoinRateDisplay if opened in same session/window (best-effort)
                 try { if (window.parent && window.parent.document) { const oneEl = window.parent.document.getElementById('oneJcoinRateDisplay'); if (oneEl && currentSystemSettings?.jcoinNairaRate) oneEl.textContent = `₦${(1/currentSystemSettings.jcoinNairaRate).toFixed(2)} NGN`; } } catch(e) {}
                     homeChipsRow.style.display = 'flex';


### PR DESCRIPTION
## Purpose

The user wanted to implement a complete wallet unlock payment flow that encourages users to pay ₦5,000 for wallet verification. The goal was to:
- Make the JCoin rate clickable to open a payment encouragement panel
- Create compelling messaging that motivates users to pay the verification fee
- Add a payment details submission form where users can upload bank transfer proof
- Integrate the flow with developer.html for wallet unlock processing

## Code changes

- **Enhanced wallet locked modal messaging**: Replaced basic text with persuasive copy highlighting benefits like "priority review", "faster access", and "secure verification"
- **Added payment details modal**: New form for users to submit bank transfer proof including fields for amount, bank name, transaction reference, payment date/time, notes, and receipt upload
- **Styled payment button**: Changed "Pay ₦5000" button to pink and yellow gradient as requested
- **Added click handlers**: JCoin rate now opens wallet locked panel, payment button opens details form
- **Integrated Firebase submission**: Payment details are saved to Firestore collection for developer review
- **Added file upload support**: Users can upload receipt screenshots via Cloudinary integrationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ad986f97b0344ddb3739822d4cf8efb/zen-oasis)

👀 [Preview Link](https://5ad986f97b0344ddb3739822d4cf8efb-zen-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ad986f97b0344ddb3739822d4cf8efb</projectId>-->
<!--<branchName>zen-oasis</branchName>-->